### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,16 +1,13 @@
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
 
-name: R-CMD-check
+name: R-CMD-check.yaml
+
+permissions: read-all
 
 jobs:
   R-CMD-check:
@@ -22,63 +19,33 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          # - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          # - {os: macOS-latest, r: 'release'}
-          # - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          # - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          # - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          # - {os: ubuntu-latest,   r: 'release'}
+          # - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 # rosettafish
 
 <!-- badges: start -->
-[![R-CMD-check](https://github.com/pbs-assess/rosettafish/workflows/R-CMD-check/badge.svg)](https://github.com/pbs-assess/rosettafish/actions)
+[![R-CMD-check](https://github.com/nafc-assess/rosettafish/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/nafc-assess/rosettafish/actions/workflows/R-CMD-check.yaml)
 [![Coverage status](https://codecov.io/gh/pbs-assess/rosettafish/branch/master/graph/badge.svg)](https://codecov.io/github/pbs-assess/rosettafish?branch=master)
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <!-- badges: start -->
 
-[![R-CMD-check](https://github.com/pbs-assess/rosettafish/workflows/R-CMD-check/badge.svg)](https://github.com/pbs-assess/rosettafish/actions)
+[![R-CMD-check](https://github.com/nafc-assess/rosettafish/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/nafc-assess/rosettafish/actions/workflows/R-CMD-check.yaml)
 [![Coverage
 status](https://codecov.io/gh/pbs-assess/rosettafish/branch/master/graph/badge.svg)](https://codecov.io/github/pbs-assess/rosettafish?branch=master)
 <!-- badges: end -->
@@ -127,9 +127,9 @@ the package immediately, follow the above instructions to add your terms
 and then open `data-raw/make-dictionary.R` and source it in R. This
 will:
 
--   sort the `data-raw/terms.csv` dictionary file alphabetically
--   stop you if there are any duplicates (fix them!)
--   save the data into the package data so it can be used
+- sort the `data-raw/terms.csv` dictionary file alphabetically
+- stop you if there are any duplicates (fix them!)
+- save the data into the package data so it can be used
 
 After sourcing this file, you can reinstall the package to use it. For
 example, with your working directory set to the rosettafish folder:
@@ -138,7 +138,7 @@ example, with your working directory set to the rosettafish folder:
 devtools::install(quick = TRUE, dependencies = FALSE)
 ```
 
-Or open the project in RStudio and run Build &gt; Install and Restart.
+Or open the project in RStudio and run Build \> Install and Restart.
 
 You will need to restart any other R sessions to be able to use the
 newly installed package.


### PR DESCRIPTION
Update github actions to avoid R-CMD-Check fail from "Error: Missing download info for actions/cache@v2". I don't understand why, but my pull request from the nafc-assess fork to the master branch caused the fail. 

Be sure to have a quick check of the update to the actions in case I missed any customizations beyond limiting it to a Windows check.